### PR TITLE
fix: invalid escape sequence

### DIFF
--- a/post_processing_nodes.py
+++ b/post_processing_nodes.py
@@ -98,7 +98,7 @@ class AsciiArt:
 
 
 def ascii_art_effect(image: torch.Tensor, char_size: int, font_size: int):
-    chars = " .'`^\",:;I1!i><-+_-?][}{1)(|\/tfjrxnuvczXYUCLQ0OZmwqpbdkhao*#MW&8%B@$"
+    chars = r" .'`^\",:;I1!i><-+_-?][}{1)(|\/tfjrxnuvczXYUCLQ0OZmwqpbdkhao*#MW&8%B@$"
     small_image = image.resize((image.size[0] // char_size, image.size[1] // char_size), Image.Resampling.NEAREST)
 
     def get_char(value):


### PR DESCRIPTION
Simple fix for the invalid escape sequence warning associated with the ascii_art_effect function:

Error:
![CleanShot 2024-09-02 at 17 04 16@2x](https://github.com/user-attachments/assets/c04a2a21-60aa-4535-9e8f-8ad85dbf2f82)

